### PR TITLE
rust: enable --all-features on rust-analyzer

### DIFF
--- a/.config/nvim/lua/custom/configs/rust-tools.lua
+++ b/.config/nvim/lua/custom/configs/rust-tools.lua
@@ -6,6 +6,11 @@ local options = {
   server = {
     on_attach = on_attach,
     capabilities = capabilities,
+    ["rust-analyzer"] = {
+      cargo = {
+        features = { "all" },
+      },
+    },
   }
 }
 


### PR DESCRIPTION
Unsure if this was intentionally not implemented when you replaced lspconfig with rust-tools, or if rust-tools this by default (though docs would suggest it does not). Here is a PR that you may or may not want. Ty for your videos on these topics.