### PR TITLE
remove obsolete, tmux yank in copy mode works again

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -48,6 +48,12 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 
 run '~/.tmux/plugins/tpm/tpm'
 
+# set vi-mode
+set-window-option -g mode-keys vi
+# keybindings
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
+
 bind '"' split-window -v -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -48,13 +48,6 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 
 run '~/.tmux/plugins/tpm/tpm'
 
-# set vi-mode
-set-window-option -g mode-keys vi
-# keybindings
-bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
-bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
-
 bind '"' split-window -v -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"


### PR DESCRIPTION
copy-selection-and-cancel seems to be renamed to copy-pipe-and-cancel, which is the default behaviour.
Removing this line will make the yank in copy mode work again.

I am using Ubuntu 24.04.
Can you test it on your side?